### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# v1.1.0 - 03/26/2026
+
+Changed
+- Raised minimum Terraform version from `>= 1.3` to `>= 1.9`
+- Raised minimum azurerm provider version from `~> 3.22` to `~> 3.116`
+- Updated azurenoopsutils provider constraint to `~> 1.0.4`
+
 # v1.0.0 - 02/03/2024
 
 Added

--- a/README.md
+++ b/README.md
@@ -229,16 +229,16 @@ An effective naming convention assembles resource names by using important resou
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.22 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.22 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/POps-Rox/tf-az-overlays-appconfiguration/pulls)
 [![Maintained](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/POps-Rox/tf-az-overlays-appconfiguration/graphs/commit-activity)
-[![Terraform](https://img.shields.io/badge/Terraform-%3E%3D1.5-623CE4.svg?logo=terraform)](https://www.terraform.io)
+[![Terraform](https://img.shields.io/badge/Terraform-%3E%3D1.9-623CE4.svg?logo=terraform)](https://www.terraform.io)
 <!-- BADGES:END -->
 
 # Azure App Configuration Overlay Terraform Module

--- a/docs/index.md
+++ b/docs/index.md
@@ -229,16 +229,16 @@ An effective naming convention assembles resource names by using important resou
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.22 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.22 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 
 ## Modules
 

--- a/examples/Commerical/basic/versions.tf
+++ b/examples/Commerical/basic/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   environment = var.environment

--- a/examples/Commerical/basic_existing_key_vault/versions.tf
+++ b/examples/Commerical/basic_existing_key_vault/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   environment = var.environment

--- a/examples/Commerical/basic_replica/versions.tf
+++ b/examples/Commerical/basic_replica/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   environment = var.environment

--- a/examples/Commerical/basic_user_assigned_identity/versions.tf
+++ b/examples/Commerical/basic_user_assigned_identity/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   environment = var.environment

--- a/examples/Government/basic/versions.tf
+++ b/examples/Government/basic/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   environment = var.environment

--- a/examples/Government/basic_existing_key_vault/versions.tf
+++ b/examples/Government/basic_existing_key_vault/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   environment = var.environment

--- a/examples/Government/basic_replica/versions.tf
+++ b/examples/Government/basic_replica/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   environment = var.environment

--- a/examples/Government/basic_user_assigned_identity/versions.tf
+++ b/examples/Government/basic_user_assigned_identity/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   environment = var.environment

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"


### PR DESCRIPTION
## Describe your changes

Modernize version constraints to current standards and ensure all example configurations enforce the same constraints.

### Changes
- Terraform `>= 1.3` → `>= 1.9`
- azurerm `~> 3.22` → `~> 3.116`
- azurenoopsutils → `~> 1.0.4`
- Fixed README badge to reflect the correct minimum Terraform version (`>= 1.9`)
- Added `terraform {}` blocks with `required_version` and `required_providers` to all 8 example `versions.tf` files (previously missing, making version constraints ineffective for example consumers)
- Updated CHANGELOG.md with v1.1.0 entry documenting the version changes

## Issue number

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)