### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Changed
 - Raised minimum Terraform version from `>= 1.3` to `>= 1.9`
 - Raised minimum azurerm provider version from `~> 3.22` to `~> 3.116`
-- Updated azurenoopsutils provider constraint to `~> 1.0.4`
+- Updated popsrox-utils provider constraint to `~> 1.0.4`
 
 # v1.0.0 - 02/03/2024
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ An effective naming convention assembles resource names by using important resou
 | [azurerm_app_configuration_feature.feature](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_feature) | resource |
 | [azurerm_app_configuration_key.test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_key) | resource |
 | [azurerm_role_assignment.appconf_dataowner](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [popsrox_resource_name.example_custom_name](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.example_custom_name](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure App Configuration Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-app-configuration/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-app-configuration/azurerm/)
 
-This Overlay terraform module creates an [Azure App Configuration](https://learn.microsoft.com/en-us/azure/azure-app-configuration/overview) with optional Key Vault for encryption enabled to be used in a [SCCA compliant Management Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest). This module has also key and feature management capabilities.
+This Overlay terraform module creates an [Azure App Configuration](https://learn.microsoft.com/en-us/azure/azure-app-configuration/overview) with optional Key Vault for encryption enabled to be used in a [SCCA compliant Management Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest). This module has also key and feature management capabilities.
 
 ## Using Azure Clouds
 
@@ -230,22 +230,22 @@ An effective naming convention assembles resource names by using important resou
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -255,7 +255,7 @@ An effective naming convention assembles resource names by using important resou
 | [azurerm_app_configuration_feature.feature](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_feature) | resource |
 | [azurerm_app_configuration_key.test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_key) | resource |
 | [azurerm_role_assignment.appconf_dataowner](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurenoopsutils_resource_name.example_custom_name](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.example_custom_name](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -255,7 +255,7 @@ An effective naming convention assembles resource names by using important resou
 | [azurerm_app_configuration_feature.feature](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_feature) | resource |
 | [azurerm_app_configuration_key.test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_key) | resource |
 | [azurerm_role_assignment.appconf_dataowner](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [popsrox_resource_name.example_custom_name](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.example_custom_name](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure App Configuration Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-app-configuration/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-app-configuration/azurerm/)
 
-This Overlay terraform module creates an [Azure App Configuration](https://learn.microsoft.com/en-us/azure/azure-app-configuration/overview) with optional Key Vault for encryption enabled to be used in a [SCCA compliant Management Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest). This module has also key and feature management capabilities.
+This Overlay terraform module creates an [Azure App Configuration](https://learn.microsoft.com/en-us/azure/azure-app-configuration/overview) with optional Key Vault for encryption enabled to be used in a [SCCA compliant Management Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest). This module has also key and feature management capabilities.
 
 ## Using Azure Clouds
 
@@ -230,22 +230,22 @@ An effective naming convention assembles resource names by using important resou
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -255,7 +255,7 @@ An effective naming convention assembles resource names by using important resou
 | [azurerm_app_configuration_feature.feature](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_feature) | resource |
 | [azurerm_app_configuration_key.test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_key) | resource |
 | [azurerm_role_assignment.appconf_dataowner](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurenoopsutils_resource_name.example_custom_name](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.example_custom_name](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/examples/Commerical/basic/README.md
+++ b/examples/Commerical/basic/README.md
@@ -12,7 +12,7 @@ provider "azurerm" {
 }
 
 module "mod_app_configuration" {
-  source  = "azurenoops/overlays-app-configuration/azurerm"
+  source  = "POps-Rox/overlays-app-configuration/azurerm"
   version = "x.x.x"
 
   # Resource Group, location, VNet and Subnet details

--- a/examples/Commerical/basic/versions.tf
+++ b/examples/Commerical/basic/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/Commerical/basic/versions.tf
+++ b/examples/Commerical/basic/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Commerical/basic/versions.tf
+++ b/examples/Commerical/basic/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Commerical/basic_existing_key_vault/README.md
+++ b/examples/Commerical/basic_existing_key_vault/README.md
@@ -12,7 +12,7 @@ provider "azurerm" {
 }
 
 module "mod_app_configuration" {
-  source  = "azurenoops/overlays-app-configuration/azurerm"
+  source  = "POps-Rox/overlays-app-configuration/azurerm"
   version = "x.x.x"
 
   depends_on = [

--- a/examples/Commerical/basic_existing_key_vault/versions.tf
+++ b/examples/Commerical/basic_existing_key_vault/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/Commerical/basic_existing_key_vault/versions.tf
+++ b/examples/Commerical/basic_existing_key_vault/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Commerical/basic_existing_key_vault/versions.tf
+++ b/examples/Commerical/basic_existing_key_vault/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Commerical/basic_replica/README.md
+++ b/examples/Commerical/basic_replica/README.md
@@ -12,7 +12,7 @@ provider "azurerm" {
 }
 
 module "mod_app_configuration" {
-  source  = "azurenoops/overlays-app-configuration/azurerm"
+  source  = "POps-Rox/overlays-app-configuration/azurerm"
   version = "x.x.x"
   
   # Resource Group, location, VNet and Subnet details

--- a/examples/Commerical/basic_replica/versions.tf
+++ b/examples/Commerical/basic_replica/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/Commerical/basic_replica/versions.tf
+++ b/examples/Commerical/basic_replica/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Commerical/basic_replica/versions.tf
+++ b/examples/Commerical/basic_replica/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Commerical/basic_user_assigned_identity/README.md
+++ b/examples/Commerical/basic_user_assigned_identity/README.md
@@ -12,7 +12,7 @@ provider "azurerm" {
 }
 
 module "mod_app_configuration" {
-  source  = "azurenoops/overlays-app-configuration/azurerm"
+  source  = "POps-Rox/overlays-app-configuration/azurerm"
   version = "x.x.x"
 
   depends_on = [

--- a/examples/Commerical/basic_user_assigned_identity/versions.tf
+++ b/examples/Commerical/basic_user_assigned_identity/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/Commerical/basic_user_assigned_identity/versions.tf
+++ b/examples/Commerical/basic_user_assigned_identity/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Commerical/basic_user_assigned_identity/versions.tf
+++ b/examples/Commerical/basic_user_assigned_identity/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Government/basic/README.md
+++ b/examples/Government/basic/README.md
@@ -12,7 +12,7 @@ provider "azurerm" {
 }
 
 module "mod_app_configuration" {
-  source  = "azurenoops/overlays-app-configuration/azurerm"
+  source  = "POps-Rox/overlays-app-configuration/azurerm"
   version = "x.x.x"
 
   # Resource Group, location, VNet and Subnet details

--- a/examples/Government/basic/versions.tf
+++ b/examples/Government/basic/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/Government/basic/versions.tf
+++ b/examples/Government/basic/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Government/basic/versions.tf
+++ b/examples/Government/basic/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Government/basic_existing_key_vault/README.md
+++ b/examples/Government/basic_existing_key_vault/README.md
@@ -12,7 +12,7 @@ provider "azurerm" {
 }
 
 module "mod_app_configuration" {
-  source  = "azurenoops/overlays-app-configuration/azurerm"
+  source  = "POps-Rox/overlays-app-configuration/azurerm"
   version = "x.x.x"
 
   depends_on = [

--- a/examples/Government/basic_existing_key_vault/versions.tf
+++ b/examples/Government/basic_existing_key_vault/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/Government/basic_existing_key_vault/versions.tf
+++ b/examples/Government/basic_existing_key_vault/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Government/basic_existing_key_vault/versions.tf
+++ b/examples/Government/basic_existing_key_vault/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Government/basic_replica/README.md
+++ b/examples/Government/basic_replica/README.md
@@ -12,7 +12,7 @@ provider "azurerm" {
 }
 
 module "mod_app_configuration" {
-  source  = "azurenoops/overlays-app-configuration/azurerm"
+  source  = "POps-Rox/overlays-app-configuration/azurerm"
   version = "x.x.x"
   
   # Resource Group, location, VNet and Subnet details

--- a/examples/Government/basic_replica/versions.tf
+++ b/examples/Government/basic_replica/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/Government/basic_replica/versions.tf
+++ b/examples/Government/basic_replica/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Government/basic_replica/versions.tf
+++ b/examples/Government/basic_replica/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Government/basic_user_assigned_identity/README.md
+++ b/examples/Government/basic_user_assigned_identity/README.md
@@ -12,7 +12,7 @@ provider "azurerm" {
 }
 
 module "mod_app_configuration" {
-  source  = "azurenoops/overlays-app-configuration/azurerm"
+  source  = "POps-Rox/overlays-app-configuration/azurerm"
   version = "x.x.x"
 
   depends_on = [

--- a/examples/Government/basic_user_assigned_identity/versions.tf
+++ b/examples/Government/basic_user_assigned_identity/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/Government/basic_user_assigned_identity/versions.tf
+++ b/examples/Government/basic_user_assigned_identity/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Government/basic_user_assigned_identity/versions.tf
+++ b/examples/Government/basic_user_assigned_identity/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,5 +8,5 @@ locals {
 
   resource_group_name    = element(coalescelist(data.azurerm_resource_group.rg.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location               = element(coalescelist(data.azurerm_resource_group.rg.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  app_configuration_name = coalesce(var.custom_app_configuration_name, data.azurenoopsutils_resource_name.example_custom_name.result)
+  app_configuration_name = coalesce(var.custom_app_configuration_name, data.popsrox_resource_name.example_custom_name.result)
 }

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "azurenoopsutils_resource_name" "example_custom_name" {
+data "popsrox_resource_name" "example_custom_name" {
   name          = var.workload_name
   resource_type = "azurerm_app_configuration"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/versions.tf
+++ b/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replaces all `azurenoops` / `azurenoopsutils` references with the renamed `POps-Rox` / `popsrox-utils` equivalents across the entire module.

## Changes
- `versions.tf` (root + 8 examples): renamed provider local name `azurenoopsutils` → `popsrox-utils` and source `azurenoops/azurenoopsutils` → `POps-Rox/popsrox-utils`
- `naming.tf`: data source type `azurenoopsutils_resource_name` → `popsrox_resource_name`
- `locals.naming.tf`: updated data source reference to match
- `CHANGELOG.md`: updated provider name
- `README.md` + `docs/index.md`: updated badge URLs, provider table, module table, and data-source table (org `azurenoops` → `POps-Rox`)
- All 8 example `README.md` files: updated module source from `azurenoops/overlays-app-configuration/azurerm` → `POps-Rox/overlays-app-configuration/azurerm`

## Testing
- `terraform fmt -recursive` passed with no changes
- `grep -rn azurenoops` returns zero matches across all `.tf`, `.md`, `.yml` files

Closes #7