### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-appconfiguration
+  name: terraform-az-overlays-appconfiguration
   description: Terraform overlay module for Azure App Configuration
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-appconfiguration
+    github.com/project-slug: POps-Rox/terraform-az-overlays-appconfiguration
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-appconfiguration
+    - url: https://github.com/POps-Rox/terraform-az-overlays-appconfiguration
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/Commerical/basic/main.tf
+++ b/examples/Commerical/basic/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic App Configuration in Azure. 
 
 module "mod_app_configuration" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-appconfiguration"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appconfiguration"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/basic_existing_key_vault/main.tf
+++ b/examples/Commerical/basic_existing_key_vault/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic App Configuration with User Assigned Identity and Existing Key Vault in Azure. 
 
 module "mod_app_configuration" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-appconfiguration"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appconfiguration"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/basic_replica/main.tf
+++ b/examples/Commerical/basic_replica/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic App Configuration with Replica Configuration in Azure. 
 
 module "mod_app_configuration" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-appconfiguration"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appconfiguration"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/basic_user_assigned_identity/main.tf
+++ b/examples/Commerical/basic_user_assigned_identity/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic App Configuration with User Assigned Identity in Azure. 
 
 module "mod_app_configuration" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-appconfiguration"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appconfiguration"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/basic/main.tf
+++ b/examples/Government/basic/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic App Configuration in Azure. 
 
 module "mod_app_configuration" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-appconfiguration"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appconfiguration"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/basic_existing_key_vault/main.tf
+++ b/examples/Government/basic_existing_key_vault/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic App Configuration with User Assigned Identity and Existing Key Vault in Azure. 
 
 module "mod_app_configuration" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-appconfiguration"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appconfiguration"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/basic_replica/main.tf
+++ b/examples/Government/basic_replica/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic App Configuration with Replica Configuration in Azure. 
 
 module "mod_app_configuration" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-appconfiguration"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appconfiguration"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/basic_user_assigned_identity/main.tf
+++ b/examples/Government/basic_user_assigned_identity/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic App Configuration with User Assigned Identity in Azure. 
 
 module "mod_app_configuration" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-appconfiguration"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appconfiguration"
   #version = "x.x.x"
   source = "../../.."
 

--- a/modules.app.configuration.scaffolding.tf
+++ b/modules.app.configuration.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azregions" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rg" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_app_config_resource_group ? 1 : 0
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.